### PR TITLE
Rest notes works in chords now

### DIFF
--- a/pyknon/genmidi.py
+++ b/pyknon/genmidi.py
@@ -1,5 +1,5 @@
 from pyknon.MidiFile import MIDIFile
-from pyknon.music import Note, NoteSeq
+from pyknon.music import Note, NoteSeq, Rest
 
 
 class MidiError(Exception):
@@ -27,10 +27,11 @@ class Midi(object):
 
         for seq in seqlist:
             if isinstance(seq, NoteSeq):
-                volume = seq[0].volume
-                dur = seq[0].midi_dur
-                for note in seq:
-                    self.midi_data.addNote(track, 0, note.midi_number, time, dur, volume)
+                if not isinstance(seq[0], Rest):
+                    volume = seq[0].volume
+                    dur = seq[0].midi_dur
+                    for note in seq:
+                        self.midi_data.addNote(track, 0, note.midi_number, time, dur, volume)
                 time += dur
             else:
                 raise MidiError("The input should be a list of NoteSeq but yours is a {0}: {1}".format(type(seqlist), seqlist))


### PR DESCRIPTION
I added a check in seq_chords that is similar to what is done in seq_notes (if it is a rest node, ignore and just increment time).
