### PR TITLE
Additional rules for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.pyc
 .coverage
 htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 .coverage
 htmlcov
 .tox


### PR DESCRIPTION
I added two rules to ignore compiled python files (.pyc) and temporary vim files (.swp).
