### PR TITLE
using Note - Note to calculate intervals instead of Note.value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ htmlcov
 .tox
 _build/
 .cache
+build/

--- a/pyknon/music.py
+++ b/pyknon/music.py
@@ -233,8 +233,8 @@ class NoteSeq(collections.MutableSequence):
 
     ## TODO: gives an error with rests
     def intervals(self):
-        v1 = [x.value for x in self]
-        v2 = [x.value for x in self.rotate()]
+        v1 = self[:]
+        v2 = self.rotate()
 
         return [y - x for x, y in zip(v1, v2[:-1])]
 

--- a/test/test_music.py
+++ b/test/test_music.py
@@ -329,8 +329,10 @@ class TestNoteSeq(unittest.TestCase):
         self.assertEqual(seq1.retrograde(), seq2)
 
     def test_intervals(self):
-        seq = NoteSeq("C D E F#")
-        self.assertEqual(seq.intervals(), [2, 2, 2])
+        seq1 = NoteSeq("C D E F#")
+        seq2 = NoteSeq("B' C''")
+        self.assertEqual(seq1.intervals(), [2, 2, 2])
+        self.assertEqual(seq2.intervals(), [1])
 
     def test_stretch_inverval(self):
         seq1 = NoteSeq("C D E")


### PR DESCRIPTION
Dear Pedro,

I noticed the interval between B' and C'' was -11. I was expecting 1 as answer, giving the ascending octaves of the notes. I also noticed that Note.**sub** gave the expected answer. Just to illustrate:

```
from pyknon.music import Note
c6 = Note("C''")
b5 = Note("B'")
c6 - b5
Out[1]: 1
NoteSeq("B' C''").intervals()
Out[2]: [-11]
```

In this way, I just changed NoteSeq.intervals() making it use Note.self instead of Note.value. It seems to fix that. What do you think? I also added a proper test.

Thank you my friend!
